### PR TITLE
Ports other than the default did not actually work due to too-early initialization of the GPCamera

### DIFF
--- a/ext/gphoto2camera.c
+++ b/ext/gphoto2camera.c
@@ -165,10 +165,8 @@ VALUE camera_allocate(VALUE klass) {
     c->lastName[0] = '\0';
     c->context = gp_context_new();
     c->disposed = 0;
+    c->config = 0;
     gp_result_check(gp_camera_new(&(c->camera)));
-    gp_result_check(gp_camera_get_config(c->camera, &(c->config), c->context));
-    gp_result_check(gp_camera_ref(c->camera));
-    gp_result_check(gp_camera_get_abilities (c->camera, &((*c).abilities)));
     return Data_Wrap_Struct(klass, camera_mark, camera_free, c);
 }
 
@@ -212,6 +210,10 @@ VALUE camera_initialize(int argc, VALUE *argv, VALUE self) {
             rb_raise(rb_eArgError, "Wrong number of arguments (%d for 0 or 1)", argc);
             return Qnil;
     }
+
+    gp_result_check(gp_camera_get_config(c->camera, &(c->config), c->context));
+    gp_result_check(gp_camera_ref(c->camera));
+    gp_result_check(gp_camera_get_abilities (c->camera, &((*c).abilities)));
     
     cfgs = rb_hash_new();
     populateWithConfigs(c->config, cfgs);


### PR DESCRIPTION
The GPCamera object was getting initialized due to the call in `camera_allocate` to `gp_camera_get_config` which ends up calling the `CHECK_INIT` macro and calling `gp_camera_new`. This meant that the default port information was always being used, since the port wasn't being set until later on in `camera_initialize`.

To fix this, I have moved the `gp_camera_get_config` and `gp_camera_get_abilities` calls to `camera_initialize`, after the port information has been configured.
